### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/opensrc/cjson/cJSON.c
+++ b/opensrc/cjson/cJSON.c
@@ -1783,7 +1783,7 @@ static cJSON *get_object_item(const cJSON * const object, const char * const nam
     current_element = object->child;
     if (case_sensitive)
     {
-        while ((current_element != NULL) && (strcmp(name, current_element->string) != 0))
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
         {
             current_element = current_element->next;
         }
@@ -1794,6 +1794,9 @@ static cJSON *get_object_item(const cJSON * const object, const char * const nam
         {
             current_element = current_element->next;
         }
+    }
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
     }
 
     return current_element;


### PR DESCRIPTION
Hi Reader Development Team,

Our tool identified a potential vulnerability in a clone function `get_object_item()` in `opensrc/cjson/cJSON.c` sourced from [DaveGamble/cJSON](https://github.com/DaveGamble/cJSON). These issues, originally reported in [CVE-2019-1010239](https://nvd.nist.gov/vuln/detail/CVE-2019-1010239), were resolved in the repository via this commit https://github.com/DaveGamble/cJSON/commit/be749d7efa7c9021da746e685bd6dec79f9dd99b.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.