### PR TITLE
Fix missing HTML entities in EPUB and MOBI text

### DIFF
--- a/Reader/EpubBook.cpp
+++ b/Reader/EpubBook.cpp
@@ -705,7 +705,10 @@ BOOL EpubBook::ParserOps(file_data_t *fdata, wchar_t **text, int *len, wchar_t *
     }
     
     xmlKeepBlanksDefault(1);
-    doc = xmlReadMemory((const char *)format_str, size, NULL, NULL, XML_PARSE_RECOVER/* | XML_PARSE_NOBLANKS*/);
+    // htmlDocDumpMemoryFormat may serialize characters such as curly quotes as
+    // HTML named entities. Reparse the formatted document as HTML so those
+    // entities survive instead of being discarded by the XML parser.
+    doc = htmlReadMemory((const char *)format_str, size, NULL, NULL, HTML_PARSE_RECOVER);
     xmlFree(format_str);
     if (!doc)
         goto end;

--- a/Reader/MobiBook.cpp
+++ b/Reader/MobiBook.cpp
@@ -637,11 +637,12 @@ BOOL MobiBook::ParserOps(file_data_t *fdata, wchar_t **text, int *len, wchar_t *
     }
     
     xmlKeepBlanksDefault(1);
-    doc = xmlReadMemory((const char *)format_str, size, NULL, NULL, XML_PARSE_RECOVER | XML_PARSE_HUGE /*| XML_PARSE_NOBLANKS */ ); //XML_PARSE_HUGE 大文件支持
+    // htmlDocDumpMemoryFormat can emit HTML named entities. The XML parser only
+    // understands XML's predefined entities and would silently lose others.
+    doc = htmlReadMemory((const char *)format_str, size, NULL, NULL, HTML_PARSE_RECOVER);
     xmlFree(format_str);
     if (!doc)
         goto end;
-    xmlDocDumpFormatMemory(doc, &format_str, &size, 1);
 #endif
     
     xpathctx = xmlXPathNewContext(doc);


### PR DESCRIPTION
## Summary

- Reparse formatted EPUB and MOBI documents with the HTML parser.
- Preserve HTML named entities such as curly quotation marks in extracted book text.
- Remove an unused second serialization in the MOBI parsing path.

## Root cause

`htmlDocDumpMemoryFormat` can serialize typographic punctuation such as `“”` as HTML named entities. The formatted document was then passed to `xmlReadMemory`, but the XML parser only recognizes XML's predefined entities. With recovery enabled, unsupported HTML entities were silently discarded before the text reached pagination and rendering.

Using `htmlReadMemory` for the second parse keeps the parser consistent with the serialized format and preserves those characters.

## User impact

EPUB and MOBI content no longer loses curly quotation marks and other HTML named entities during text extraction. This change does not modify font or transparent-window rendering.

## Validation

- Reproduced with an EPUB chapter containing curly quotation marks.
- Confirmed the original parser removed the characters before layout/rendering.
- x64 Release build completed successfully with MSVC v143 on Windows Server 2022.

